### PR TITLE
Fixed ThumbnailCell layout

### DIFF
--- a/Auto Layout/ThumbnailCell.swift
+++ b/Auto Layout/ThumbnailCell.swift
@@ -46,6 +46,7 @@ final class ThumbnailCell: BottomSeparatorCell {
 
     NSLayoutConstraint.activate([
       imageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: textView.textContainerInset.top),
+      imageView.bottomAnchor.constraint(lessThanOrEqualTo: textView.bottomAnchor).withPriority(.required - 1),
       imageView.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
       imageView.widthAnchor.constraint(equalToConstant: thumbnailSize.width),
       imageView.heightAnchor.constraint(equalToConstant: thumbnailSize.height)


### PR DESCRIPTION
If the headline or summary of a ThumbnailCell is too short, the thumbnail overlaps with the save and share button at the bottom. This PR fixes it.

### Before:

![Simulator Screen Shot - iPhone 11 Pro - 2020-09-28 at 12 56 13](https://user-images.githubusercontent.com/50334428/94462952-3cacbc00-018a-11eb-9574-b12fc959315a.png)

### After:

![after](https://user-images.githubusercontent.com/50334428/94462962-40404300-018a-11eb-8554-8814fae6adcf.png)
